### PR TITLE
Library Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ As a collection of scripts and applications, the Distant Reader has only been bu
    * OpenStack - a tool for building virtual machines
    * Slurm - a tool for instantiating a cluster of computer nodes and what runs on them
    * Airivata - a Web-based suite of software used to monitor computing jobs on a cluster
-   * Other Python Libraries - sqlalchemy, pandas, itertools, wordcloud, scipy, matplotlib, sklearn, networkx, textatistic, nltk, mpl_toolkits, cgitb, cgi
+   * Other Python Libraries - sqlalchemy, pandas, itertools, wordcloud, scipy, sklearn, networkx, textatistic, nltk
    * Other Perl Modules - DBI, JSON, Archive::Zip, WebService::Solr, XML::XPath, CGI, File::Basename, File::Copy, HTML::Entities, HTML::Escape
    * Javascript Libraries - bootstap, jquery 
    * Other Programs - csvstack

--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ As a collection of scripts and applications, the Distant Reader has only been bu
    * OpenStack - a tool for building virtual machines
    * Slurm - a tool for instantiating a cluster of computer nodes and what runs on them
    * Airivata - a Web-based suite of software used to monitor computing jobs on a cluster
+   * Python Libraries - sqlalchemy, pandas, itertools, wordcloud, scipy, matplotlib, sklearn, tika, gensim, textacy, networkx, textatistic, nltk, spacy, mpl_toolkits, cgitb, cgi
+   * Perl Modules - DBI, JSON, Archive::Zip, WebService::Solr, XML::XPath, CGI, File::Basename, File::Copy, HTML::Entities, HTML::Escape
+   * Javascript Libraries - bootstap, jquery 
+   * Other Programs - csvstack
 
 The Distant Reader takes one of five different types of input:
 

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ As a collection of scripts and applications, the Distant Reader has only been bu
    * OpenStack - a tool for building virtual machines
    * Slurm - a tool for instantiating a cluster of computer nodes and what runs on them
    * Airivata - a Web-based suite of software used to monitor computing jobs on a cluster
-   * Python Libraries - sqlalchemy, pandas, itertools, wordcloud, scipy, matplotlib, sklearn, tika, gensim, textacy, networkx, textatistic, nltk, spacy, mpl_toolkits, cgitb, cgi
-   * Perl Modules - DBI, JSON, Archive::Zip, WebService::Solr, XML::XPath, CGI, File::Basename, File::Copy, HTML::Entities, HTML::Escape
+   * Other Python Libraries - sqlalchemy, pandas, itertools, wordcloud, scipy, matplotlib, sklearn, networkx, textatistic, nltk, mpl_toolkits, cgitb, cgi
+   * Other Perl Modules - DBI, JSON, Archive::Zip, WebService::Solr, XML::XPath, CGI, File::Basename, File::Copy, HTML::Entities, HTML::Escape
    * Javascript Libraries - bootstap, jquery 
    * Other Programs - csvstack
 


### PR DESCRIPTION
Added missing libraries and looked up their licenses in https://github.com/molikd/reader/issues/1

mostly Perl/Python libraries. 

See issue for license documentation.

-Dave