### PR TITLE
Add indexes to CORD sqlite schema

### DIFF
--- a/bin/json2corpus.sh
+++ b/bin/json2corpus.sh
@@ -12,7 +12,6 @@
 # configure
 TXT='./cord/txt'
 DB='./etc/cord.db'
-TEMPLATE=".mode tabs\nSELECT document_id, cord_uid FROM documents WHERE sha='##SHA##'";
 JSON2TXT='./bin/json2txt.sh'
 
 if [[ -z $1 ]]; then
@@ -27,7 +26,7 @@ JSON=$1
 SHA=$( basename $JSON .json )
 
 # build an SQL query, and find some other (pseudo) keys
-QUERY=$( echo $TEMPLATE | sed "s/##SHA##/$SHA/" )
+QUERY=".mode tabs\nSELECT document_id, cord_uid FROM documents WHERE sha='$SHA'";
 IFS=$'\t'
 printf $QUERY | sqlite3 $DB | while read DOCID CORDID; do
 

--- a/bin/json2txt.sh
+++ b/bin/json2txt.sh
@@ -33,11 +33,9 @@ if [[ "$SHA" == $PMC_FILE_ID ]]; then
 	ID_COLUMN="pmc_id"
 fi
 
-TEMPLATE=".mode tabs\nSELECT authors, title, date, journal, doi, abstract, \
-document_id, cord_uid FROM documents WHERE ${ID_COLUMN} is '##SHA##';"
-
 # get more metadata
-QUERY=$( echo $TEMPLATE | sed "s/##SHA##/$SHA/" )
+QUERY=".mode tabs\nSELECT authors, title, date, journal, doi, abstract, \
+document_id, cord_uid FROM documents WHERE ${ID_COLUMN} is '$SHA';"
 IFS=$'\t'
 printf $QUERY | sqlite3 $DB | while read -a RESULTS; do
 

--- a/etc/schema-cord.sql
+++ b/etc/schema-cord.sql
@@ -32,6 +32,8 @@ CREATE TABLE documents (
     
 );
 
+CREATE INDEX documents_sha_i ON documents (sha);
+CREATE INDEX documents_pmc_id_i ON documents (pmc_id);
 
 -- name entitites
 CREATE TABLE ent (


### PR DESCRIPTION
A few CORD processing scripts use these to index into the documents
table. The indicies keep it from doing a full table scan when doing
these lookups.

Also change a few SQL strings to use bash interpolation instead of
shelling out to sed.